### PR TITLE
Adding readme file to the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+prune *
+include README.rst
+include setup.py
+recursive-include xvfbwrapper *.py


### PR DESCRIPTION
pip install xvfbwrapper -throwing a file not found error.

https://groups.google.com/forum/?fromgroups#!searchin/selenium-users/xvfbwrapper/selenium-users/7jSHvr5rUDs/KwH8Q_UkxMkJ

Adding readme file to the source distribution would solve this.
