### PR TITLE
Send SIGTERM to all Xvfb processes.

### DIFF
--- a/xvfbwrapper/xvfbwrapper.py
+++ b/xvfbwrapper/xvfbwrapper.py
@@ -14,6 +14,7 @@ import fnmatch
 import random
 import subprocess
 import time
+import signal
 
 
 class Xvfb(object):
@@ -40,7 +41,8 @@ class Xvfb(object):
         self.xvfb_proc = subprocess.Popen(self.xvfb_cmd,
             stdout=open(os.devnull),
             stderr=open(os.devnull),
-            shell=True
+            shell=True,
+            preexec_fn=os.setsid
         )
         time.sleep(0.1)  # give Xvfb time to start
         self._redirect_display(self.vdisplay_num)
@@ -48,8 +50,7 @@ class Xvfb(object):
     def stop(self):
         self._redirect_display(self.old_display_num)
         if self.xvfb_proc is not None:
-            self.xvfb_proc.kill()
-            self.xvfb_proc.wait()
+            os.killpg(self.xvfb_proc.pid, signal.SIGTERM)
             self.xvfb_proc = None
 
     def search_for_free_display(self):


### PR DESCRIPTION
There is a dangling process bug in the code as it stands. Try this:
  In [1]: from xvfbwrapper import Xvfb
  In [2]: vdisplay = Xvfb(width=1280, height=720)
  In [3]: vdisplay.start()
    => [In another shell, check all Xvfb, you will find there are two. ]
  In [4]: vdisplay.stop()
    => [Check Xvfb, you will find one left.]

In the code in this commit, there is a group for all processes started by 
subprocess.  This group is then send SIGTERM thus killing all the processes 
started. 