### PR TITLE
prepare Popen for OSError exception

### DIFF
--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -10,6 +10,7 @@
 
 
 import os
+import sys
 import fnmatch
 import random
 import subprocess
@@ -48,10 +49,15 @@ class Xvfb:
         self.vdisplay_num = self.search_for_free_display()
         self.xvfb_cmd = ['Xvfb', ':%d' % self.vdisplay_num] + self.xvfb_cmd
 
-        self.proc = subprocess.Popen(self.xvfb_cmd,
-                                     stdout=open(os.devnull),
-                                     stderr=open(os.devnull),
-                                     )
+        try:
+            self.proc = subprocess.Popen(self.xvfb_cmd,
+                                         stdout=open(os.devnull),
+                                         stderr=open(os.devnull),
+                                         )
+        except OSError:
+            print >> sys.stderr, 'Failed to run %s' % ' '.join(self.xvfb_cmd)
+            return 0
+
         time.sleep(0.2)  # give Xvfb time to start
         ret_code = self.proc.poll()
         if ret_code is None:


### PR DESCRIPTION
Hi,

If xvfb is not installed, and running the tests, the following output is generated:

```python
======================================================================
ERROR: testGoogleHomepage (__main__.TestPages)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "xx.py", line 12, in setUp
    self.xvfb.start()
  File "/home/danclaudiupop/envs/account/local/lib/python2.7/site-packages/xvfbwrapper.py", line 55, in start
    stderr=open(os.devnull),
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1259, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

I prepared the app for OSError exception and provided a more friendly error message.  Also, this makes it so we can run the tests even if we didn't start the tests from an X session.

```
testGoogleHomepage (__main__.TestPages) ... Failed to run Xvfb :1095 -screen 0 1280x720x24
ok
```