### PR TITLE
Support for unary args

### DIFF
--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -65,7 +65,7 @@ class TestXvfb(unittest.TestCase):
         self.assertIsNotNone(xvfb.proc)
 
     def test_start_with_arbitrary_kwargs(self):
-        xvfb = Xvfb(nolisten='tcp')
+        xvfb = Xvfb(nolisten='tcp', noreset=None)
         self.addCleanup(xvfb.stop)
         xvfb.start()
         display_var = ':{}'.format(xvfb.new_display)

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -30,7 +30,10 @@ class Xvfb:
                                 self.width, self.height, self.colordepth)]
 
         for key, value in kwargs.items():
-            self.extra_xvfb_args += ['-{}'.format(key), value]
+            if value:
+                self.extra_xvfb_args += ['-{}'.format(key), value]
+            else:
+                self.extra_xvfb_args.append('-{}'.format(key))
 
         if 'DISPLAY' in os.environ:
             self.orig_display = os.environ['DISPLAY'].split(':')[1]


### PR DESCRIPTION
This adds support for Xvfb arguments which do not have values (e.g. `-noreset`).