### PR TITLE
prevent screen number exhaustion

### DIFF
--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -81,10 +81,11 @@ class Xvfb:
         lockfile_names = fnmatch.filter(os.listdir(tmpdir), pattern)
         existing_displays = [int(name.split('X')[1].split('-')[0])
                              for name in lockfile_names]
-        for i in range(1, max(existing_displays)):
-            if i not in existing_displays:
-                return i
-        return max(existing_displays) + 1
+        if existing_displays:
+            for i in range(1, max(existing_displays)):
+                if i not in existing_displays:
+                    return i
+        return max(existing_displays) + 1 if existing_displays else 1
 
     def _set_display_var(self, display):
         os.environ['DISPLAY'] = ':{}'.format(display)

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -81,8 +81,10 @@ class Xvfb:
         lockfile_names = fnmatch.filter(os.listdir(tmpdir), pattern)
         existing_displays = [int(name.split('X')[1].split('-')[0])
                              for name in lockfile_names]
-        highest_display = max(existing_displays) if existing_displays else 0
-        return highest_display + 1
+        for i in range(1, max(existing_displays)):
+            if i not in existing_display:
+                return i
+        return max(existing_displays) + 1
 
     def _set_display_var(self, display):
         os.environ['DISPLAY'] = ':{}'.format(display)

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -82,7 +82,7 @@ class Xvfb:
         existing_displays = [int(name.split('X')[1].split('-')[0])
                              for name in lockfile_names]
         for i in range(1, max(existing_displays)):
-            if i not in existing_display:
+            if i not in existing_displays:
                 return i
         return max(existing_displays) + 1
 


### PR DESCRIPTION
In current master, the screen number can only grow if multiple screens are opened and new one are created before the old ones are closed. 
The solution is not quite elegant, but I guess it's worth mentioning.