### PR TITLE
Fix multiprocessing X display collisions by utilizing `flock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,89 @@
-MANIFEST
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
-__pycache__
-_build
-build
-dist
-sdist
-.tox
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
 *.egg
-*.egg-info
-eggs
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 before_install:
   - "sudo apt-get update -qq"
   - "sudo apt-get install -y xvfb"

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,22 @@
 
 
 import os
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 this_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_dir, 'README.rst')) as f:
     LONG_DESCRIPTION = '\n' + f.read()
 
+tests_require = []
+try:
+    from unittest import mock  # noqa
+except ImportError:
+    tests_require.append('mock')
 
 setup(
     name='xvfbwrapper',
@@ -23,6 +32,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     url='https://github.com/cgoldberg/xvfbwrapper',
     download_url='http://pypi.python.org/pypi/xvfbwrapper',
+    tests_require=tests_require,
     keywords='xvfb virtual display headless x11'.split(),
     license='MIT',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
 
 setup(
     name='xvfbwrapper',
-    version='0.2.9dev',
+    version='0.2.9.dev0',
     py_modules=['xvfbwrapper'],
     author='Corey Goldberg',
     author_email='cgoldberg _at_ gmail.com',

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -89,13 +89,19 @@ class TestXvfb(unittest.TestCase):
         self.addCleanup(xvfb._cleanup_lock_file)
         self.addCleanup(xvfb2._cleanup_lock_file)
         self.addCleanup(xvfb3._cleanup_lock_file)
+        side_effect = [11, 11, 22, 11, 22, 11, 22, 22, 22, 33]
         with patch('xvfbwrapper.randint',
-                   side_effect=[11, 11, 22, 11, 22, 11, 22, 22, 22, 33]):
+                   side_effect=side_effect) as mockrandint:
             self.assertEqual(xvfb._get_next_unused_display(), 11)
+            self.assertEqual(mockrandint.call_count, 1)
             if sys.version_info >= (3, 2):
                 with self.assertWarns(ResourceWarning):
                     self.assertEqual(xvfb2._get_next_unused_display(), 22)
+                    self.assertEqual(mockrandint.call_count, 3)
                     self.assertEqual(xvfb3._get_next_unused_display(), 33)
+                    self.assertEqual(mockrandint.call_count, 10)
             else:
                 self.assertEqual(xvfb2._get_next_unused_display(), 22)
+                self.assertEqual(mockrandint.call_count, 3)
                 self.assertEqual(xvfb3._get_next_unused_display(), 33)
+                self.assertEqual(mockrandint.call_count, 10)

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -19,6 +19,12 @@ class TestXvfb(unittest.TestCase):
     def setUp(self):
         self.reset_display()
 
+    def test_xvfb_binary_not_exists(self):
+        with patch('xvfbwrapper.Xvfb.xvfb_exists') as xvfb_exists:
+            xvfb_exists.return_value = False
+            with self.assertRaises(EnvironmentError):
+                Xvfb()
+
     def test_start(self):
         xvfb = Xvfb()
         self.addCleanup(xvfb.stop)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist=flake8,py27,py33,py34,py35,pypy
 
 [testenv]
 commands={envpython} -m unittest discover
+deps=
+    py27,pypy: mock
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
Fixes: #16 & #15, makes #14 obsolete

I've run into this issue as well.

This change uses [fcntl.flock](https://docs.python.org/3/library/fcntl.html#fcntl.flock) to create a lock file, ensuring multi-process safe display IDs.

It includes a test case, however I've not yet tested it using a production load. I expect to in the next week or so.

Let me know if you have any questions. Hopefully this change puts all concurrency issues to rest.