### PR TITLE
catch KeyError on stop

### DIFF
--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -81,7 +81,10 @@ class Xvfb(object):
     def stop(self):
         try:
             if self.orig_display is None:
-                del os.environ['DISPLAY']
+                try:
+                    del os.environ['DISPLAY']
+                except KeyError:
+                    pass
             else:
                 self._set_display_var(self.orig_display)
             if self.proc is not None:


### PR DESCRIPTION
prevents the following error msg I keep getting:
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/opt/anaconda2/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(_targs, *_kargs)
  File "/opt/anaconda2/lib/python2.7/site-packages/xvfbwrapper.py", line 67, in stop
    del os.environ['DISPLAY']
  File "/opt/anaconda2/lib/python2.7/os.py", line 498, in __delitem__
    del self.data[key]
KeyError: 'DISPLAY'
