### PR TITLE
continue on PermissionError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
 
 setup(
     name='xvfbwrapper',
-    version='0.2.10dev',
+    version='0.2.10dev-b',
     py_modules=['xvfbwrapper'],
     author='Corey Goldberg',
     author_email='cgoldberg _at_ gmail.com',

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -126,11 +126,11 @@ class Xvfb(object):
         tempfile_path = os.path.join(self._tempdir, '.X{0}-lock')
         while True:
             rand = randint(1, self.__class__.MAX_DISPLAY)
-            self._lock_display_file = open(tempfile_path.format(rand), 'w')
             try:
+                self._lock_display_file = open(tempfile_path.format(rand), 'w')
                 fcntl.flock(self._lock_display_file,
                             fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
+            except (BlockingIOError, PermissionError):
                 continue
             else:
                 return rand


### PR DESCRIPTION
I've seen PermissionError raised here under python 3.6.1 when calling `os.fork()` multiple times after initialization. I do not reseed for `random.randint()` in the child processes so this is nicely reproducible in these circumstances.

```
File \"/app/foo/bar.py\", line X, in baz",
      "    with Xvfb(width=1920, height=1080):",
      "  File \"/usr/local/lib/python3.6/dist-packages/xvfbwrapper.py\", line 57, in __enter__",
      "    self.start()",
      "  File \"/usr/local/lib/python3.6/dist-packages/xvfbwrapper.py\", line 64, in start",
      "    self.new_display = self._get_next_unused_display()",
      "  File \"/usr/local/lib/python3.6/dist-packages/xvfbwrapper.py\", line 123, in _get_next_unused_display",
      "    self._lock_display_file = open(tempfile_path.format(rand), 'w')",
      "PermissionError: [Errno 13] Permission denied: '/tmp/.X1050355074-lock'",
      ""
```

If you want to accept this PR I can clean up the change to setup.py. 

Thanks for a great module 🥇 