### PR TITLE
 Support gracefully shutdown when SIGINT/Ctrl+C

### DIFF
--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -67,6 +67,7 @@ class Xvfb(object):
             self.proc = subprocess.Popen(self.xvfb_cmd,
                                          stdout=fnull,
                                          stderr=fnull,
+                                         preexec_fn=os.setpgrp,
                                          close_fds=True)
         # give Xvfb time to start
         time.sleep(self.__class__.SLEEP_TIME_BEFORE_START)


### PR DESCRIPTION
Detach subprocess from interpreter's process group, avoids receiving SIGINT from it.

When hitting Ctrl+C, the subprocess Xvfb (and webdriver/selenium), receives SIGINT and shutdown, probably before the custom clean-up code. (race condition)

If I use a class Page to wrap around selenium, and have a clean-up code in __exit__ to close the opened window:
```
class Page:
  def __init__(self, wd):
    self.wd=wd
  def __enter__(self):
    // open window by js, and calculate the opened window handle
    self.window = // set(new_window_handles) - set(new_window_handles)
  def __exit__(self, *a):
    //xvfb and webdriver stop here, and...
    self.switch_to(self.window)  // cause this line fails
    self.close()
```