### PR TITLE
Preserve all egg-info files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ prune *
 include README.rst
 include LICENSE
 include *.py
+include *.egg-info\*


### PR DESCRIPTION
Fixes #33, this file also can be deleted as I have not seen impact on output between this version and file explictly removed. Your choice.