### PR TITLE
Add display argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,21 @@ Xvfb is useful for running acceptance tests on headless servers.
 
 ----
 
+*******************************************
+    Basic Usage, specifying display number:
+*******************************************
+
+.. code:: python
+
+    from xvfbwrapper import Xvfb
+
+    vdisplay = Xvfb(display=23)
+    vdisplay.start()
+    # Xvfb is started with display :23
+    # see vdisplay.new_display
+
+----
+
 *******************************
     Usage as a Context Manager:
 *******************************

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -52,6 +52,16 @@ class TestXvfb(unittest.TestCase):
         self.assertEqual(display_var, os.environ['DISPLAY'])
         self.assertIsNotNone(xvfb.proc)
 
+    def test_start_with_specific_display(self):
+        xvfb = Xvfb(display=42)
+        xvfb2 = Xvfb(display=42)
+        self.addCleanup(xvfb.stop)
+        xvfb.start()
+        self.assertEqual(xvfb.new_display, 42)
+        self.assertIsNotNone(xvfb.proc)
+        with self.assertRaises(ValueError):
+            xvfb2.start()
+
     def test_as_context_manager(self):
         orig_display = os.environ['DISPLAY']
         with Xvfb() as xvfb:

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -28,12 +28,13 @@ class Xvfb(object):
     MAX_DISPLAY = 2147483647
     SLEEP_TIME_BEFORE_START = 0.1
 
-    def __init__(self, width=800, height=680, colordepth=24, tempdir=None,
+    def __init__(self, width=800, height=680, colordepth=24, tempdir=None, display=None,
                  **kwargs):
         self.width = width
         self.height = height
         self.colordepth = colordepth
         self._tempdir = tempdir or tempfile.gettempdir()
+        self.new_display = display
 
         if not self.xvfb_exists():
             msg = 'Can not find Xvfb. Please install it and try again.'
@@ -60,7 +61,11 @@ class Xvfb(object):
         self.stop()
 
     def start(self):
-        self.new_display = self._get_next_unused_display()
+        if self.new_display is not None:
+            if not self._get_lock_for_display(self.new_display):
+                raise ValueError("Could not lock display :{0}".format(self.new_display))
+        else:
+            self.new_display = self._get_next_unused_display()
         display_var = ':{}'.format(self.new_display)
         self.xvfb_cmd = ['Xvfb', display_var] + self.extra_xvfb_args
         with open(os.devnull, 'w') as fnull:

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -13,12 +13,16 @@ import tempfile
 import time
 
 from random import randint
+from errno import EACCES
 
+PY2 = False
 try:
     BlockingIOError
 except NameError:
     # python 2
     BlockingIOError = IOError
+    PermissionError = IOError
+    PY2 = True
 
 
 class Xvfb(object):
@@ -131,7 +135,9 @@ class Xvfb(object):
         tempfile_path = os.path.join(self._tempdir, '.X{0}-lock'.format(display))
         try:
             self._lock_display_file = open(tempfile_path, 'w')
-        except PermissionError:
+        except PermissionError as e:
+            if PY2 and e.errno != EACCES:
+                raise
             return False
         else:
             try:

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -123,15 +123,19 @@ class Xvfb(object):
         to acquire an exclusive lock on a temporary file whose name
         contains the display number for Xvfb.
         '''
-        tempfile_path = os.path.join(self._tempdir, '.X{0}-lock')
-        self._lock_display_file = open(tempfile_path.format(display), 'w')
+        tempfile_path = os.path.join(self._tempdir, '.X{0}-lock'.format(display))
         try:
-            fcntl.flock(self._lock_display_file,
-                        fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
+            self._lock_display_file = open(tempfile_path, 'w')
+        except PermissionError:
             return False
         else:
-            return True
+            try:
+                fcntl.flock(self._lock_display_file,
+                            fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                return False
+            else:
+                return True
 
     def _get_next_unused_display(self):
         '''


### PR DESCRIPTION
Adding possibility to define the display to start on.
Inspired by pull request #37, will fix issue #23.

Compared to PR #37 i changed the position of the argument to not break the interface for whoever would use the tempdir argument. Also the PR introduced a bug that when a display was specified and it was already locked, it would end up in an infinite loop.

Also added a test and an explanation to the readme.
Besides that fixed(?) a bug, in the locking method when an actual Xvfb is running. The tests which currently handle this do not start an actual instance and thus behave differently. 

Additional question: is a ValueError the one we would desire when a display is specified but it is already locked? I did not come of with a more suitable one, but maybe ppl have other wishes/opinions about it?