### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "pypy"
 jobs:
  exclude:
-  - python: pypy
+  - python: "pypy"
     arch: ppc64le
     
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
+      arch: amd64
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      arch: ppc64le
+      
 # /end python 3.7 hack
 before_install:
   - "sudo apt-get update -qq"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
+jobs:
+ exclude:
+  - python: pypy
+    arch: ppc64le
+    
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 # Should be able to remove this wierd stuff once
 # https://github.com/travis-ci/travis-ci/issues/9815 is resolved


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/xvfbwrapper

Please let me know if you need any further details.

Thank You !!