### PR TITLE
fixed race condition

### DIFF
--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -39,6 +39,7 @@ class Xvfb(object):
             msg = 'Can not find Xvfb. Please install it and try again.'
             raise EnvironmentError(msg)
 
+        self.xvfb_cmd = []
         self.extra_xvfb_args = ['-screen', '0', '{}x{}x{}'.format(
                                 self.width, self.height, self.colordepth)]
 
@@ -69,8 +70,8 @@ class Xvfb(object):
         else:
             self.new_display = self._get_next_unused_display()
         display_var = ':{}'.format(self.new_display)
-        xvfb_cmd = ['Xvfb', display_var] + self.extra_xvfb_args
-        self.proc = subprocess.Popen(xvfb_cmd,
+        self.xvfb_cmd = ['Xvfb', display_var] + self.extra_xvfb_args
+        self.proc = subprocess.Popen(self.xvfb_cmd,
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL,
                                      close_fds=True)
@@ -79,14 +80,14 @@ class Xvfb(object):
             time.sleep(1e-3)
             if time.time() - start > self._timeout:
                 self.stop()
-                raise RuntimeError('Xvfb display did not open: {}'.format(xvfb_cmd))
+                raise RuntimeError('Xvfb display did not open: {}'.format(self.xvfb_cmd))
         ret_code = self.proc.poll()
         if ret_code is None:
             self._set_display(display_var)
         else:
             self._cleanup_lock_file()
             raise RuntimeError('Xvfb did not start ({0}): {1}'
-                               .format(ret_code, xvfb_cmd))
+                               .format(ret_code, self.xvfb_cmd))
 
     def stop(self):
         try:

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -78,7 +78,8 @@ class Xvfb(object):
         while not local_display_exists(self.new_display):
             time.sleep(1e-3)
             if time.time() - start > self._timeout:
-                raise TimeoutError
+                self.stop()
+                raise RuntimeError('Xvfb display did not open: {}'.format(xvfb_cmd))
         ret_code = self.proc.poll()
         if ret_code is None:
             self._set_display(display_var)


### PR DESCRIPTION
fixes #30 and fixes #36

I ran into a very rare intermittent failure in a test which starts a Qt application and connects to a virtual framebuffer constructed with xvfb. The cause was the race condition between xvfb creating the framebuffer and the Qt application starting.
Under normal circumstances the error is quite rare (happening in 1/2500 runs or so) but the same situation can be emulated with:
```python
Xvfb.SLEEP_TIME_BEFORE_START = 0
while True:
    with Xvfb():
        app = QApplication([])
        app.exit()
```
which crashes almost immediately with
```
qt.qpa.xcb: could not connect to display :12345
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, webgl, xcb.


Process finished with exit code 134 (interrupted by signal 6: SIGABRT)
```

I have replaced the fixed timeout with a loop which waits for the Unix domain socket for the display to exist (which I assume means the display is ready). With this change the above snippet no longer crashes.

An added benefit is that the startup is also much faster (taking only about 5ms on average on my machine).

I know the chances of getting this pull request merged is slim as the project seems abandoned, but this might be useful for other people who run into this problem.