### PR TITLE
Update Python supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # supported python versions can be found here
         # https://github.com/actions/python-versions/releases
-        python-version: [pypy-2.7, 2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy-3.11]
     steps:
       - uses: actions/checkout@master
       - name: set up Python ${{ matrix.python-version }}
@@ -21,12 +21,7 @@ jobs:
           pip install -U wheel
           pip install -U coverage
           pip install .
-      - name: Install python 2.7 dependencies
-        if: "matrix.python-version == '2.7' || matrix.python-version == 'pypy-2.7'"
-        run: |
-          pip install -U mock
       - name: Run mypy
-        if: "matrix.python-version != '2.7' && matrix.python-version != 'pypy-2.7'"
         run: |
             pip install -U mypy
             mypy -p xvfbwrapper --ignore-missing-imports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # supported python versions can be found here
         # https://github.com/actions/python-versions/releases
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy-3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
     steps:
       - uses: actions/checkout@master
       - name: set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,14 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.env/
+.venv/
+.ENV/
+.VENV/
+env/
 venv/
 ENV/
+VENV/
 
 # Spyder project settings
 .spyderproject

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-xvfbwrapper - Copyright (c) 2012-2019 Corey Goldberg
+xvfbwrapper - Copyright (c) 2012-2025 Corey Goldberg
 
 MIT License
 

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,6 @@
 
 **Manage headless displays with Xvfb (X virtual framebuffer)**
 
-.. image:: https://travis-ci.org/cgoldberg/xvfbwrapper.svg?branch=master
-    :target: https://travis-ci.org/cgoldberg/xvfbwrapper
-
 ----
 
 ---------
@@ -16,7 +13,7 @@
 
 - Dev: https://github.com/cgoldberg/xvfbwrapper
 - Releases: https://pypi.org/project/xvfbwrapper/
-- Author: `Corey Goldberg <https://github.com/cgoldberg>`_ - 2012-2019
+- Author: `Corey Goldberg <https://github.com/cgoldberg>`_ - 2012-2025
 - License: MIT
 
 ----
@@ -55,7 +52,7 @@ Xvfb is useful for running acceptance tests on headless servers.
 
 * X11 Windowing System
 * Xvfb (`sudo apt-get install xvfb`, `yum install xorg-x11-server-Xvfb`, etc)
-* Python 2.7 or 3.6+
+* Python 3.8+
 
 ----
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@
 
 import os
 import setuptools
-import sys
 
 
 VERSION = '0.2.10.dev'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 """distutils setup/install script for xvfbwrapper"""
@@ -16,22 +16,16 @@ this_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_dir, 'README.rst')) as f:
     LONG_DESCRIPTION = '\n' + f.read()
 
-TESTS_REQUIRE = []
-if sys.version_info.major < 3:
-    TESTS_REQUIRE.append('mock')
-
 
 setuptools.setup(
     name='xvfbwrapper',
     version=VERSION,
     py_modules=['xvfbwrapper'],
     author='Corey Goldberg',
-    author_email='cgoldberg _at_ gmail.com',
     description='Manage headless displays with Xvfb (X virtual framebuffer)',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/cgoldberg/xvfbwrapper',
-    download_url='https://pypi.python.org/pypi/xvfbwrapper',
-    tests_require=TESTS_REQUIRE,
+    download_url='https://pypi.python.org/project/xvfbwrapper',
     keywords='xvfb headless virtual display x11 testing'.split(),
     license='MIT',
     classifiers=[
@@ -40,13 +34,12 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -3,10 +3,8 @@
 import os
 import sys
 import unittest
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+
+from unittest.mock import patch
 
 from xvfbwrapper import Xvfb
 
@@ -149,4 +147,3 @@ class TestXvfb(unittest.TestCase):
             self.assertEqual(':0', os.environ['DISPLAY'])
             self.assertEqual(':0', env_duped['DISPLAY'])
             self.assertIsNone(xvfb.proc)
-

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import unittest
 
 from unittest.mock import patch

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -43,11 +43,9 @@ class TestXvfb(unittest.TestCase):
     def test_stop_with_xquartz(self):
         # Check that xquartz pattern for display server is dealt with by
         # xvfb.stop() and restored appropriately
-        xquartz_display = '/private/tmp/com.apple.launchd.CgDzCWvNb1/org.macosforge.xquartz:0'
-        with patch.dict('os.environ',
-           {
-               'DISPLAY':xquartz_display
-           }) as mocked_env:
+        xquartz_display = '/private/tmp/com.apple.launchd.CgDzCWvNb1/' + \
+            'org.macosforge.xquartz:0'
+        with patch.dict('os.environ', {'DISPLAY': xquartz_display}):
             xvfb = Xvfb()
             xvfb.start()
             self.assertNotEqual(xquartz_display, os.environ['DISPLAY'])
@@ -140,10 +138,7 @@ class TestXvfb(unittest.TestCase):
                 self.assertEqual(mockrandint.call_count, 10)
 
     def test_environ_keyword_isolates_environment_modification(self):
-        with patch.dict('os.environ',
-           {
-               'DISPLAY':':0'
-           }) as mocked_env:
+        with patch.dict('os.environ', {'DISPLAY': ':0'}):
             # Check that start and stop methods modified the environ dict if
             # passed and does not modify os.environ
             env_duped = os.environ.copy()

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -126,18 +126,11 @@ class TestXvfb(unittest.TestCase):
                    side_effect=side_effect) as mockrandint:
             self.assertEqual(xvfb._get_next_unused_display(), 11)
             self.assertEqual(mockrandint.call_count, 1)
-            if sys.version_info >= (3, 2):
-                with self.assertWarns(ResourceWarning):
-                    self.assertEqual(xvfb2._get_next_unused_display(), 22)
-                    self.assertEqual(mockrandint.call_count, 3)
-                    self.assertEqual(xvfb3._get_next_unused_display(), 33)
-                    self.assertEqual(mockrandint.call_count, 10)
-            else:
+            with self.assertWarns(ResourceWarning):
                 self.assertEqual(xvfb2._get_next_unused_display(), 22)
                 self.assertEqual(mockrandint.call_count, 3)
                 self.assertEqual(xvfb3._get_next_unused_display(), 33)
                 self.assertEqual(mockrandint.call_count, 10)
-
 
     def test_environ_keyword_isolates_environment_modification(self):
         with patch.dict('os.environ',

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -41,14 +41,13 @@ class TestXvfb(unittest.TestCase):
         self.assertIsNone(xvfb.proc)
 
     def test_stop_with_xquartz(self):
-        # check that xquartz pattern for display server is dealt with by
+        # Check that xquartz pattern for display server is dealt with by
         # xvfb.stop() and restored appropriately
         xquartz_display = '/private/tmp/com.apple.launchd.CgDzCWvNb1/org.macosforge.xquartz:0'
         with patch.dict('os.environ',
            {
                'DISPLAY':xquartz_display
            }) as mocked_env:
-
             xvfb = Xvfb()
             xvfb.start()
             self.assertNotEqual(xquartz_display, os.environ['DISPLAY'])
@@ -124,12 +123,22 @@ class TestXvfb(unittest.TestCase):
                    side_effect=side_effect) as mockrandint:
             self.assertEqual(xvfb._get_next_unused_display(), 11)
             self.assertEqual(mockrandint.call_count, 1)
-            with self.assertWarns(ResourceWarning):
+            if sys.implementation.name == 'cpython':
+                # ResourceWarning is only raised on CPython because
+                # of an implementation detail in it's garbage collector.
+                # This does not occur on other Python implementations
+                # (like PyPy)
+                with self.assertWarns(ResourceWarning):
+                    self.assertEqual(xvfb2._get_next_unused_display(), 22)
+                    self.assertEqual(mockrandint.call_count, 3)
+                    self.assertEqual(xvfb3._get_next_unused_display(), 33)
+                    self.assertEqual(mockrandint.call_count, 10)
+            else:
                 self.assertEqual(xvfb2._get_next_unused_display(), 22)
                 self.assertEqual(mockrandint.call_count, 3)
                 self.assertEqual(xvfb3._get_next_unused_display(), 33)
                 self.assertEqual(mockrandint.call_count, 10)
-
+    
     def test_environ_keyword_isolates_environment_modification(self):
         with patch.dict('os.environ',
            {

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -138,7 +138,7 @@ class TestXvfb(unittest.TestCase):
                 self.assertEqual(mockrandint.call_count, 3)
                 self.assertEqual(xvfb3._get_next_unused_display(), 33)
                 self.assertEqual(mockrandint.call_count, 10)
-    
+
     def test_environ_keyword_isolates_environment_modification(self):
         with patch.dict('os.environ',
            {

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -3,8 +3,10 @@
 import os
 import sys
 import unittest
-
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from xvfbwrapper import Xvfb
 
@@ -156,3 +158,4 @@ class TestXvfb(unittest.TestCase):
             self.assertEqual(':0', os.environ['DISPLAY'])
             self.assertEqual(':0', env_duped['DISPLAY'])
             self.assertIsNone(xvfb.proc)
+

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -3,10 +3,8 @@
 import os
 import sys
 import unittest
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+
+from unittest.mock import patch
 
 from xvfbwrapper import Xvfb
 
@@ -158,4 +156,3 @@ class TestXvfb(unittest.TestCase):
             self.assertEqual(':0', os.environ['DISPLAY'])
             self.assertEqual(':0', env_duped['DISPLAY'])
             self.assertIsNone(xvfb.proc)
-

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,py38,py39,py310,py311,py312,pypy
+envlist = flake8,py38,py39,py310,py311,py312,py313,pypy3
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,py27,py36,py37,py38,py39,pypy
+envlist = flake8,py38,py39,py310,py311,py312,pypy
 
 [testenv]
 commands = {envpython} setup.py test

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -3,7 +3,7 @@
 # License: MIT
 
 
-"""Run a headless display inside X virtual framebuffer (Xvfb)"""
+'''Run a headless display inside X virtual framebuffer (Xvfb)'''
 
 
 import fcntl
@@ -22,8 +22,8 @@ class Xvfb(object):
     MAX_DISPLAY = 2147483647
     SLEEP_TIME_BEFORE_START = 0.1
 
-    def __init__(self, width=800, height=680, colordepth=24, tempdir=None, display=None,environ=None,
-                 **kwargs):
+    def __init__(self, width=800, height=680, colordepth=24, tempdir=None,
+                 display=None, environ=None, **kwargs):
         self.width = width
         self.height = height
         self.colordepth = colordepth
@@ -63,7 +63,9 @@ class Xvfb(object):
     def start(self):
         if self.new_display is not None:
             if not self._get_lock_for_display(self.new_display):
-                raise ValueError("Could not lock display :{0}".format(self.new_display))
+                raise ValueError(
+                    'Could not lock display :{0}'.format(self.new_display)
+                )
         else:
             self.new_display = self._get_next_unused_display()
         display_var = ':{}'.format(self.new_display)
@@ -101,7 +103,7 @@ class Xvfb(object):
 
     def xvfb_exists(self):
         # type: (...) -> bool
-        """Check that Xvfb is available on PATH and is executable."""
+        '''Check that Xvfb is available on PATH and is executable.'''
         paths = self.environ['PATH'].split(os.pathsep)
         return any(os.access(os.path.join(path, 'Xvfb'), os.X_OK)
                    for path in paths)
@@ -130,10 +132,12 @@ class Xvfb(object):
         to acquire an exclusive lock on a temporary file whose name
         contains the display number for Xvfb.
         '''
-        tempfile_path = os.path.join(self._tempdir, '.X{0}-lock'.format(display))
+        tempfile_path = os.path.join(
+            self._tempdir, '.X{0}-lock'.format(display)
+        )
         try:
             self._lock_display_file = open(tempfile_path, 'w')
-        except PermissionError as e:
+        except PermissionError:
             return False
         else:
             try:
@@ -147,8 +151,9 @@ class Xvfb(object):
     def _get_next_unused_display(self):
         # type: (...) -> int
         '''
-        Randomly chooses a display number and tries to acquire a lock for this number.
-        If the lock could be acquired, returns this number, otherwise choses a new one.
+        Randomly chooses a display number and tries to acquire a lock for this
+        number. If the lock could be acquired, returns this number, otherwise
+        choses a new one.
         :return: free display number
         '''
         while True:

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
-#   * Corey Goldberg, 2012, 2013, 2015, 2016, 2017
+#   * Corey Goldberg, 2012-2025
 
 
 """Run a headless display inside X virtual framebuffer (Xvfb)"""

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#
-#   * Corey Goldberg, 2012-2025
+# Corey Goldberg, 2012-2025
+# License: MIT
 
 
 """Run a headless display inside X virtual framebuffer (Xvfb)"""
@@ -13,16 +13,6 @@ import tempfile
 import time
 
 from random import randint
-from errno import EACCES
-
-PY2 = False
-try:
-    BlockingIOError
-except NameError:
-    # python 2
-    BlockingIOError = IOError
-    PermissionError = IOError
-    PY2 = True
 
 
 class Xvfb(object):
@@ -144,8 +134,6 @@ class Xvfb(object):
         try:
             self._lock_display_file = open(tempfile_path, 'w')
         except PermissionError as e:
-            if PY2 and e.errno != EACCES:
-                raise
             return False
         else:
             try:


### PR DESCRIPTION
This PR updates the versions of Python that xvfbwrapper supports.

- Python 2.7, 3.6, 3.7, and PyPy 2.7 support was dropped.
- Python 3.10, 3.11, 3.12, 3.13, and PyPy 3.11 support was added.
- GitHub Actions were fixed up accordingly.
- Also includes some minor code cleanup.
- All flake8 warnings are fixed.
- All CI workflows pass.
