### PR TITLE
Update tox config for linting and type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,21 +7,20 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.eggs/
+.installed.cfg
 .Python
-env/
 build/
 develop-eggs/
 dist/
 downloads/
 eggs/
-.eggs/
 lib/
 lib64/
 parts/
 sdist/
 var/
 *.egg-info/
-.installed.cfg
 *.egg
 
 # PyInstaller
@@ -31,19 +30,23 @@ var/
 *.spec
 
 # Installer logs
-pip-log.txt
 pip-delete-this-directory.txt
+pip-log.txt
 
 # Unit test / coverage reports
-htmlcov/
-.tox/
+.cache
 .coverage
 .coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*,cover
 .hypothesis/
+.pytest_cache/
+.tox/
+coverage.xml
+htmlcov/
+nosetests.xml
+*,cover
+
+# Type checking
+.mypy_cache/
 
 # Translations
 *.mo
@@ -54,8 +57,8 @@ coverage.xml
 local_settings.py
 
 # Flask stuff:
-instance/
 .webassets-cache
+instance/
 
 # Scrapy stuff:
 .scrapy

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 import setuptools
 
 
-VERSION = '0.2.10.dev'
+VERSION = '0.2.10.dev0'
 
 
 this_dir = os.path.abspath(os.path.dirname(__file__))

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,31 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
+#
+# For a specific environment, run: "tox -e <env>" (i.e.: "tox -e py311")
 
 [tox]
-envlist = flake8,py38,py39,py310,py311,py312,py313,pypy3
+env_list = type, lint, py38, py39, py310, py311, py312, py313, pypy3
 
 [testenv]
-commands = {envpython} setup.py test
+description = run unit tests
+deps =
+    pytest
+commands =
+    pytest
 
-[testenv:flake8]
-deps = flake8
-commands = {envpython} -m flake8
+[testenv:lint]
+description = run linters
+deps =
+    flake8
+    black
+commands = 
+    {env_python} -m flake8 --extend-exclude {env_dir} {work_dir} -v
+    {env_python} -m black --check --diff --color --skip-string-normalization {posargs:.}
+
+[testenv:type]
+description = run type checks
+deps =
+    mypy
+commands =
+    {env_python} -m mypy --install-types --non-interactive {posargs:.}


### PR DESCRIPTION
Updated `tox.ini` with some new options:

* new `lint` environment with flake8 and black for linting
* new `type` environment with mypy for type checking
* switched to pytest for running unit tests

Also includes:

* minor re-organization of `.gitconfig`
* update to the version number is `setup.py`
