### PR TITLE
Raise an error if running on an unsupported platform.

### DIFF
--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -6,11 +6,15 @@
 '''Run a headless display inside X virtual framebuffer (Xvfb)'''
 
 
-import fcntl
 import os
 import subprocess
 import tempfile
 import time
+
+try:
+    import fcntl
+except ImportError:
+    raise EnvironmentError(f'xvfbwrapper is not supported on this platform.')
 
 from random import randint
 


### PR DESCRIPTION
If we cant import `fcntl`, raise `EnvironmentError` so users aren't confused when attempting to run on unsupported platforms.