### PR TITLE
Drop Python 3.9 and Support Python 3.10

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -29,7 +29,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with: # optional arguments

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
       matrix:
         # supported python versions can be found here
         # https://github.com/actions/python-versions/releases
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
     steps:
       - uses: actions/checkout@master
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license-files = ["LICENSE"]
 authors = [{name = "Corey Goldberg"}]
 maintainers = [{name = "Corey Goldberg"}]
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 keywords = ["Xvfb", "headless", "display", "X11", "X Window System"]
 classifiers = [
         "Environment :: Console",
@@ -23,11 +23,11 @@ classifiers = [
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
@@ -65,13 +65,13 @@ addopts = "-vv" # extra verbose
 [tool.black]
 line-length = 88
 target-version = [
-    "py39", "py310", "py311", "py312", "py313"
+    "py310", "py311", "py312", "py313", "py314"
 ]
 
 [tool.ruff]
 line-length = 88
 respect-gitignore = true
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [
@@ -88,7 +88,7 @@ docstring-code-format = true
 docstring-code-line-length = 88
 
 [tool.refurb]
-python_version = "3.9"
+python_version = "3.10"
 enable_all = true
 disable = [
     "FURB107", "FURB173", "FURB183", "FURB184"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # supported python versions. To use it, run "tox" from this directory.
 #
 # For a specific environment, run:
-#     "tox -e <env>" (i.e.: "tox -e py313" or "tox -e lint")
+#     "tox -e <env>" (i.e.: "tox -e py314" or "tox -e lint")
 #
 # This tox configuration will skip any Python interpreters that can't be found.
 # To manage multiple Python interpreters for covering all versions, you can use
@@ -15,11 +15,11 @@ envlist =
     validate
     lint
     type
-    py39
     py310
     py311
     py312
     py313
+    py314
     pypy3
 skip_missing_interpreters = true
 


### PR DESCRIPTION
This PR:

- Adds Python 3.14 support to packaging and tests
- Drops Python 3.9 support from packaging and tests
- Updates CI workflow actions to latest versions

There are no code changes.