### PR TITLE
Pass custom environment to Xvfb subprocess

### DIFF
--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -360,20 +360,14 @@ class TestXvfb(XvfbCleanTestCase):
         self.assertIsNone(xvfb.proc)
 
     def test_environ_is_passed_to_xvfb_subprocess(self):
-        # Verify that the custom environment is used by the Xvfb process itself,
-        # not just for managing DISPLAY.
         marker_value = "xvfbwrapper_test_marker_12345"
         custom_env = os.environ.copy()
         custom_env["XVFBWRAPPER_TEST_MARKER"] = marker_value
-
         xvfb = Xvfb(environ=custom_env)
         self.addCleanup(xvfb.stop)
         xvfb.start()
-
         proc = psutil.Process(xvfb.proc.pid)
-        self.assertEqual(
-            proc.environ().get("XVFBWRAPPER_TEST_MARKER"), marker_value
-        )
+        self.assertEqual(proc.environ().get("XVFBWRAPPER_TEST_MARKER"), marker_value)
 
     def test_start_failure_without_initial_display_env(self):
         # Provide a custom env *without* DISPLAY so orig_display_var == None

--- a/test_xvfb.py
+++ b/test_xvfb.py
@@ -359,6 +359,22 @@ class TestXvfb(XvfbCleanTestCase):
         self.assertEqual(":0", env_duped["DISPLAY"])
         self.assertIsNone(xvfb.proc)
 
+    def test_environ_is_passed_to_xvfb_subprocess(self):
+        # Verify that the custom environment is used by the Xvfb process itself,
+        # not just for managing DISPLAY.
+        marker_value = "xvfbwrapper_test_marker_12345"
+        custom_env = os.environ.copy()
+        custom_env["XVFBWRAPPER_TEST_MARKER"] = marker_value
+
+        xvfb = Xvfb(environ=custom_env)
+        self.addCleanup(xvfb.stop)
+        xvfb.start()
+
+        proc = psutil.Process(xvfb.proc.pid)
+        self.assertEqual(
+            proc.environ().get("XVFBWRAPPER_TEST_MARKER"), marker_value
+        )
+
     def test_start_failure_without_initial_display_env(self):
         # Provide a custom env *without* DISPLAY so orig_display_var == None
         custom_env = {"PATH": os.environ.get("PATH", "")}

--- a/xvfbwrapper.py
+++ b/xvfbwrapper.py
@@ -111,6 +111,7 @@ class Xvfb:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             close_fds=True,
+            env=dict(self.environ),
         )
         start = time.time()
         while not self._local_display_exists(self.new_display):


### PR DESCRIPTION
## Summary

This PR makes sure the `environ` parameter is used when launching the `Xvfb` subprocess.

Currently, `environ` is used to manage the `DISPLAY` variable, but it isn't passed to `subprocess.Popen()`. Due to this, the child process always inherits `os.environ` instead of the custom environment provided by the caller.